### PR TITLE
explicitly sort returned hash keys

### DIFF
--- a/lib/Box/Calc.pm
+++ b/lib/Box/Calc.pm
@@ -201,7 +201,7 @@ has box_type_categories => (
             next if $box_type->category eq '';
             $categories{$box_type->category} = 1;
         }
-        return [keys %categories];
+        return [sort keys %categories];
     },
 );
 


### PR DESCRIPTION
corrects intermittent test failures, ran test suite 25x on 5.22 to confirm