### PR TITLE
Minor fixes

### DIFF
--- a/lib/Box/Calc.pm
+++ b/lib/Box/Calc.pm
@@ -590,6 +590,13 @@ sub reset_items {
     $self->clear_max_dimensions_of_items;
 }
 
+=head2 make_box($box_type)
+
+Handy method to create  new box using a specified
+box type.
+
+=cut
+
 sub make_box {
     my ($self, $box_type) = @_;
     return Box::Calc::Box->new(

--- a/lib/Box/Calc/Box.pm
+++ b/lib/Box/Calc/Box.pm
@@ -300,10 +300,22 @@ sub packing_instructions {
   };
 }
 
+=head2 used_volume
+
+Returns the real used volume for this box.
+
+=cut
+
 sub used_volume {
     my $self = shift;
     return sum map { $_->used_volume } @{ $self->layers };
 }
+
+=head2 volume 
+
+Returns the exact volume needed for this box.    
+
+=cut
 
 sub volume {
     return $_[0]->fill_x * $_[0]->fill_y * $_[0]->fill_z;
@@ -311,3 +323,5 @@ sub volume {
 
 no Moose;
 __PACKAGE__->meta->make_immutable;
+
+=for Pod::Coverage BUILD

--- a/lib/Box/Calc/BoxType.pm
+++ b/lib/Box/Calc/BoxType.pm
@@ -75,6 +75,12 @@ has category => (
     default     => '',
 );
 
+=head2 describe
+
+Returns a hash ref with the properties of this box type.
+
+=cut
+
 sub describe {
     my $self = shift;
     return {

--- a/lib/Box/Calc/Layer.pm
+++ b/lib/Box/Calc/Layer.pm
@@ -242,6 +242,18 @@ sub packing_instructions {
     }
 }
 
+
+=head2 used_volume
+
+Returns the real used volume for this layer.
+
+=head2 volume 
+
+Returns the exact volume needed for this layer.    
+
+=cut
+
+
 sub used_volume {
     my $self = shift;
     return sum map { $_->used_volume || 0 } @{ $self->rows };
@@ -254,3 +266,6 @@ sub volume {
 
 no Moose;
 __PACKAGE__->meta->make_immutable;
+
+=for Pod::Coverage BUILD
+

--- a/lib/Box/Calc/Layer.pm
+++ b/lib/Box/Calc/Layer.pm
@@ -244,7 +244,7 @@ sub packing_instructions {
 
 sub used_volume {
     my $self = shift;
-    return sum map { $_->used_volume } @{ $self->rows };
+    return sum map { $_->used_volume || 0 } @{ $self->rows };
 }
 
 

--- a/lib/Box/Calc/Role/Container.pm
+++ b/lib/Box/Calc/Role/Container.pm
@@ -86,7 +86,7 @@ has outer_extent => (
     required    => 1,
 );
 
-=item max_weight
+=head2 max_weight
 
 The max weight of the items including the container. Defaults to 1000.
 

--- a/lib/Box/Calc/Row.pm
+++ b/lib/Box/Calc/Row.pm
@@ -188,6 +188,17 @@ sub packing_instructions {
     };
 }
 
+
+=head2 used_volume
+
+Returns the real used volume for this row.
+
+=head2 volume 
+
+Returns the exact volume needed for this row.    
+
+=cut
+
 sub used_volume {
     my $self = shift;
     return sum map { $_->volume } @{ $self->items };


### PR DESCRIPTION
This PR includes:
- fix a warning when using an uninitialized value;
- fix a `=item` in the middle of `=head2` commands;
- added some stub comments to some methods where they were missing.
