### PR TITLE
Add meta.json creation to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,10 +7,11 @@ copyright_year   = 2014
 version = 1.0200
 
 [@Classic]
+[MetaJSON]
 
 [MetaResources]
 bugtracker.web    = http://github.com/rizen/Box-Calc/issues
-repository.url    = git://github.com/rizen/Box-Calc.git 
+repository.url    = git://github.com/rizen/Box-Calc.git
 repository.web    = http://github.com/rizen/Box-Calc
 repository.type   = git
 


### PR DESCRIPTION
This is just a small commit to have distzilla create a meta.json file. This will resolve the "Extra Issue" mentioned on https://cpants.cpanauthors.org/release/RIZEN/Box-Calc-1.0200