### PR TITLE
Updates to fix failing test on Perls compiled with -Duselongdouble

### DIFF
--- a/lib/Box/Calc/Box.pm
+++ b/lib/Box/Calc/Box.pm
@@ -225,7 +225,7 @@ sub pack_item {
         return 0;
     }
     # item height > ( box height - box fill + the height of the current layer )
-    if ($item->z > $self->z - $self->fill_z + $self->layers->[-1]->fill_z) {
+    if ($item->z > sprintf("%.9f", $self->z - $self->fill_z + $self->layers->[-1]->fill_z)) {
         $log->info($item->{name}.' would make the layer too tall to fit in the box, requesting new box.');
         return 0;
     }
@@ -234,7 +234,7 @@ sub pack_item {
         return 1;
     }
     else {
-        if ($item->z > $self->z - $self->fill_z) {
+        if ($item->z > sprintf("%.9f", $self->z - $self->fill_z)) {
             $log->info($item->{name}.' is too big to create another layer in this box, requesting another box.');
             return 0;
         }

--- a/lib/Box/Calc/Layer.pm
+++ b/lib/Box/Calc/Layer.pm
@@ -181,7 +181,7 @@ sub pack_item {
     }
     my $fill_z = $self->fill_z;
     my $fill_y = $self->fill_y;
-    if ($item->y > $self->max_y - $fill_y + $self->rows->[-1]->fill_y # item would make the layer too wide
+    if ($item->y > sprintf("%.9f", $self->max_y - $fill_y + $self->rows->[-1]->fill_y) # item would make the layer too wide
         ) {
         $log->info($item->{name}.' would make the layer too wide, requesting new layer.');
         return 0;
@@ -194,7 +194,7 @@ sub pack_item {
         return 1;
     }
     else {
-        if ($item->y > $self->max_y - $self->fill_y) {
+        if ($item->y > sprintf("%.9f", $self->max_y - $self->fill_y)) {
             $log->info($item->{name}.' will not fit in a new row in this layer, requesting new layer.');
             return 0;
         }

--- a/lib/Box/Calc/Row.pm
+++ b/lib/Box/Calc/Row.pm
@@ -137,7 +137,7 @@ A L<Box::Calc::Item> instance.
 
 sub pack_item {
     my ($self, $item) = @_;
-    if ($item->x > $self->max_x - $self->fill_x) {
+    if ($item->x > sprintf("%.9f", $self->max_x - $self->fill_x)) {
         $log->info('No room in row for '.$item->{name}.', requesting new row.');
         return 0;
     }


### PR DESCRIPTION
Regarding Issue #12, the error seems to be due to tiny numerical errors resulting from the arithmetic and causing comparisons to fail at edge cases. The solution I have used here is to use sprintf() to round the result to some fixed precision before the comparison. Only the changes to Box.pm are required to fix the failing test but I have modified a few other places where the issue might manifest.
Thanks
